### PR TITLE
Fixed:Wifi signal does not show dynamically.

### DIFF
--- a/apps/fling-home/js/page_helper.js
+++ b/apps/fling-home/js/page_helper.js
@@ -259,7 +259,7 @@ var PageHelper = {
         if (!wifiStatusUI) {
             return;
         }
-        navigator.mozWifiManager.onconnectionInfoUpdate = function(event) {
+        navigator.mozWifiManager.onconnectioninfoupdate = function(event) {
             console.log('WiFi Status:', 'signalStrength =', event.signalStrength,
                 'relSignalStrength  =', event.relSignalStrength, 'linkSpeed =', event.linkSpeed,
                 'ipAddress =', event.ipAddress, 'network =', event.network);


### PR DESCRIPTION
We change wifi signal callback function to 'onconnectioninfoupdate'

Signed-off-by: Jianmin Zhou toandrew@infthink.com
