### PR TITLE
Notify flingd about current device name

### DIFF
--- a/apps/fling-home/js/connection_service.js
+++ b/apps/fling-home/js/connection_service.js
@@ -1314,6 +1314,10 @@ var ConnectService = (function () {
                         'tethering.wifi.security.type': 'open'
                     });
 
+                    // set init device name, then we notify flingd
+                    deviceName = castName;
+                    notifyNameChanged();
+
                     handleTimezoneSet("Asia/Shanghai", false);
                     code = genKeyCode();
                     var storeObj = {


### PR DESCRIPTION
When dongle first booted, in order to make mdns/ssdp work, need let flingd know our device name.

Signed-off-by: Jianmin Zhou toandrew@infthink.com
